### PR TITLE
connection timeout added

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -16,8 +16,14 @@ func readFTP(conn net.Conn, g *Glutton) (msg string, err error) {
 }
 
 // HandleFTP takes a net.Conn and does basic FTP communication
-func (g *Glutton) HandleFTP(conn net.Conn) {
-	defer conn.Close()
+func (g *Glutton) HandleFTP(conn net.Conn) (err error) {
+	defer func() {
+		err = conn.Close()
+		if err != nil {
+			g.logger.Errorf("[ftp     ]  %v", err)
+		}
+	}()
+
 	conn.Write([]byte("220 Welcome!\r\n"))
 	for {
 		msg, err := readFTP(conn, g)
@@ -33,4 +39,5 @@ func (g *Glutton) HandleFTP(conn net.Conn) {
 			conn.Write([]byte("200 OK.\r\n"))
 		}
 	}
+	return nil
 }

--- a/protocols.go
+++ b/protocols.go
@@ -8,38 +8,38 @@ import (
 // mapProtocolHandlers map protocol handlers to corresponding protocol
 func (g *Glutton) mapProtocolHandlers() {
 
-	g.protocolHandlers["smtp"] = func(conn net.Conn) {
-		g.HandleSMTP(conn)
+	g.protocolHandlers["smtp"] = func(conn net.Conn) error {
+		return g.HandleSMTP(conn)
 	}
-	g.protocolHandlers["rdp"] = func(conn net.Conn) {
-		g.HandleRDP(conn)
+	g.protocolHandlers["rdp"] = func(conn net.Conn) error {
+		return g.HandleRDP(conn)
 	}
-	g.protocolHandlers["smb"] = func(conn net.Conn) {
-		g.HandleSMB(conn)
+	g.protocolHandlers["smb"] = func(conn net.Conn) error {
+		return g.HandleSMB(conn)
 	}
-	g.protocolHandlers["ftp"] = func(conn net.Conn) {
-		g.HandleFTP(conn)
+	g.protocolHandlers["ftp"] = func(conn net.Conn) error {
+		return g.HandleFTP(conn)
 	}
-	g.protocolHandlers["sip"] = func(conn net.Conn) {
-		g.HandleSIP(conn)
+	g.protocolHandlers["sip"] = func(conn net.Conn) error {
+		return g.HandleSIP(conn)
 	}
-	g.protocolHandlers["rfb"] = func(conn net.Conn) {
-		g.HandleRFB(conn)
+	g.protocolHandlers["rfb"] = func(conn net.Conn) error {
+		return g.HandleRFB(conn)
 	}
-	g.protocolHandlers["telnet"] = func(conn net.Conn) {
-		g.HandleTelnet(conn)
+	g.protocolHandlers["telnet"] = func(conn net.Conn) error {
+		return g.HandleTelnet(conn)
 	}
-	g.protocolHandlers["proxy_ssh"] = func(conn net.Conn) {
-		g.sshProxy.handle(conn)
+	g.protocolHandlers["proxy_ssh"] = func(conn net.Conn) error {
+		return g.sshProxy.handle(conn)
 	}
-	g.protocolHandlers["default"] = func(conn net.Conn) {
+	g.protocolHandlers["default"] = func(conn net.Conn) error {
 		snip, bufConn, err := g.Peek(conn, 4)
 		g.onErrorClose(err, conn)
 		httpMap := map[string]bool{"GET ": true, "POST": true, "HEAD": true, "OPTI": true}
 		if _, ok := httpMap[strings.ToUpper(string(snip))]; ok == true {
-			g.HandleHTTP(bufConn)
+			return g.HandleHTTP(bufConn)
 		} else {
-			g.HandleTCP(bufConn)
+			return g.HandleTCP(bufConn)
 		}
 	}
 }

--- a/rdp.go
+++ b/rdp.go
@@ -8,14 +8,20 @@ import (
 )
 
 // HandleRDP takes a net.Conn and does basic RDP communication
-func (g *Glutton) HandleRDP(conn net.Conn) {
-	defer conn.Close()
+func (g *Glutton) HandleRDP(conn net.Conn) (err error) {
+	defer func() {
+		err = conn.Close()
+		if err != nil {
+			g.logger.Errorf("[rdp     ]  %v", err)
+		}
+	}()
+
 	buffer := make([]byte, 1024)
 	for {
 		n, err := conn.Read(buffer)
 		if err != nil && n <= 0 {
 			g.logger.Errorf("[rdp     ] error: %v", err)
-			break
+			return err
 		}
 		if n > 0 && n < 1024 {
 			g.logger.Infof("[rdp     ]\n%s", hex.Dump(buffer[0:n]))

--- a/sip.go
+++ b/sip.go
@@ -9,8 +9,14 @@ import (
 )
 
 // HandleSIP takes a net.Conn and does basic SIP communication
-func (g *Glutton) HandleSIP(netConn net.Conn) {
-	defer netConn.Close()
+func (g *Glutton) HandleSIP(netConn net.Conn) (err error) {
+	defer func() {
+		err = netConn.Close()
+		if err != nil {
+			g.logger.Errorf("[sip     ]  %v", err)
+		}
+	}()
+
 	sipConn := &sipnet.Conn{
 		Conn: netConn,
 	}
@@ -22,7 +28,7 @@ func (g *Glutton) HandleSIP(netConn net.Conn) {
 	}
 	if req == nil {
 		g.logger.Info("[sip     ] failed to parse SIP req")
-		return
+		return nil
 	}
 	g.logger.Infof("[sip     ] SIP method: %s", req.Method)
 	switch req.Method {
@@ -45,4 +51,5 @@ func (g *Glutton) HandleSIP(netConn net.Conn) {
 		resp.WriteTo(sipConn, req)
 		break
 	}
+	return nil
 }

--- a/system.go
+++ b/system.go
@@ -23,10 +23,8 @@ func countRunningRoutines() int {
 	return runtime.NumGoroutine()
 }
 
-func (g *Glutton) startMonitor() {
+func (g *Glutton) startMonitor(quit chan struct{}) {
 	ticker := time.NewTicker(10 * time.Second)
-	// TODO: return channel and stop monitor on shutdown
-	quit := make(chan struct{})
 	go func() {
 		for {
 			select {
@@ -35,6 +33,7 @@ func (g *Glutton) startMonitor() {
 				runningRoutines := countRunningRoutines()
 				g.logger.Infof("[system  ] Running Go routines: %d and open files: %d", openFiles, runningRoutines)
 			case <-quit:
+				g.logger.Info("[system  ] Monitoring stopped..")
 				ticker.Stop()
 				return
 			}

--- a/tcp.go
+++ b/tcp.go
@@ -7,9 +7,9 @@ import (
 )
 
 // HandleTCP takes a net.Conn and peeks at the data send
-func (g *Glutton) HandleTCP(conn net.Conn) {
+func (g *Glutton) HandleTCP(conn net.Conn) (err error) {
 	defer func() {
-		err := conn.Close()
+		err = conn.Close()
 		if err != nil {
 			g.logger.Errorf("[log.tcp ] %v", err)
 		}
@@ -24,4 +24,5 @@ func (g *Glutton) HandleTCP(conn net.Conn) {
 	if n > 0 && n < 1024 {
 		g.logger.Infof("[log.tcp ] %s\n%s", host, hex.Dump(buffer[0:n]))
 	}
+	return err
 }

--- a/telnet.go
+++ b/telnet.go
@@ -27,23 +27,23 @@ var miraiCom = map[string][]string{
 	"nc":   []string{"nc: command not found"},
 	"wget": []string{"wget: missing URL"},
 	"(dd bs=52 count=1 if=.s || cat .s)": []string{"\x7f\x45\x4c\x46\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00\x01\x00\x00\x00\xbc\x14\x01\x00\x34\x00\x00\x00"},
-	"sh": []string{"$"},
-	"sh || shell": 					   []string{"$"},
-	"enable\x00":		   			   []string{"-bash: enable: command not found"},
-	"system\x00":		   			   []string{"-bash: system: command not found"},
-	"shell\x00":		   			   []string{"-bash: shell: command not found"},
-	"sh\x00":		   			   []string{"$"},
-//	"fgrep XDVR /mnt/mtd/dep2.sh\x00":		   []string{"cd /mnt/mtd && ./XDVRStart.hisi ./td3500 &"},
-	"busybox":					   []string{"BusyBox v1.16.1 (2014-03-04 16:00:18 CST) built-it shell (ash)\r\nEnter 'help' for a list of built-in commands.\r\n"},
+	"sh":          []string{"$"},
+	"sh || shell": []string{"$"},
+	"enable\x00":  []string{"-bash: enable: command not found"},
+	"system\x00":  []string{"-bash: system: command not found"},
+	"shell\x00":   []string{"-bash: shell: command not found"},
+	"sh\x00":      []string{"$"},
+	//	"fgrep XDVR /mnt/mtd/dep2.sh\x00":		   []string{"cd /mnt/mtd && ./XDVRStart.hisi ./td3500 &"},
+	"busybox": []string{"BusyBox v1.16.1 (2014-03-04 16:00:18 CST) built-it shell (ash)\r\nEnter 'help' for a list of built-in commands.\r\n"},
 	"echo -ne '\\x48\\x6f\\x6c\\x6c\\x61\\x46\\x6f\\x72\\x41\\x6c\\x6c\\x61\\x68\\x0a'\r\n": []string{"\x48\x6f\x6c\x6c\x61\x46\x6f\x72\x41\x6c\x6c\x61\x68\x0arn"},
-	"cat | sh":		   			   []string{""},
+	"cat | sh": []string{""},
 	"echo -e \\x6b\\x61\\x6d\\x69/dev > /dev/.nippon":              []string{""},
 	"cat /dev/.nippon":                                             []string{"kami/dev"},
 	"rm /dev/.nippon":                                              []string{""},
 	"echo -e \\x6b\\x61\\x6d\\x69/run > /run/.nippon":              []string{""},
 	"cat /run/.nippon":                                             []string{"kami/run"},
 	"rm /run/.nippon":                                              []string{""},
-	"cat /bin/sh":                                     		[]string{"\x7f\x45\x4c\x46\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x28\x00\x01\x00\x00\x00\x98\x30\x00\x00\x34\x00\x00\x00"},
+	"cat /bin/sh":                                                  []string{"\x7f\x45\x4c\x46\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x28\x00\x01\x00\x00\x00\x98\x30\x00\x00\x34\x00\x00\x00"},
 	"/bin/busybox ps":                                              []string{"1 pts/21   00:00:00 init"},
 	"/bin/busybox cat /proc/mounts":                                []string{"tmpfs /run tmpfs rw,nosuid,noexec,relatime,size=3231524k,mode=755 0 0"},
 	"/bin/busybox echo -e \\x6b\\x61\\x6d\\x69/dev > /dev/.nippon": []string{""},
@@ -130,8 +130,13 @@ func getSample(cmd string, g *Glutton) error {
 }
 
 // HandleTelnet handles telnet communication on a connection
-func (g *Glutton) HandleTelnet(conn net.Conn) {
-	defer conn.Close()
+func (g *Glutton) HandleTelnet(conn net.Conn) (err error) {
+	defer func() {
+		err = conn.Close()
+		if err != nil {
+			g.logger.Errorf("[telnet  ]  %v", err)
+		}
+	}()
 
 	// TODO (glaslos): Add device banner
 
@@ -140,16 +145,16 @@ func (g *Glutton) HandleTelnet(conn net.Conn) {
 
 	// User name prompt
 	writeMsg(conn, "Username: ", g)
-	_, err := readMsg(conn, g)
+	_, err = readMsg(conn, g)
 	if err != nil {
 		g.logger.Errorf("[telnet  ] %v", err)
-		return
+		return err
 	}
 	writeMsg(conn, "Password: ", g)
 	_, err = readMsg(conn, g)
 	if err != nil {
 		g.logger.Errorf("[telnet  ] %v", err)
-		return
+		return err
 	}
 
 	writeMsg(conn, "welcome\r\n> ", g)
@@ -157,7 +162,7 @@ func (g *Glutton) HandleTelnet(conn net.Conn) {
 		msg, err := readMsg(conn, g)
 		if err != nil {
 			g.logger.Errorf("[telnet  ] %v", err)
-			return
+			return err
 		}
 		for _, cmd := range strings.Split(msg, ";") {
 			if strings.Contains(strings.Trim(cmd, " "), "wget http") {


### PR DESCRIPTION
#72 fixed!
`[user.tcp] accept tcp [::]:5000: accept4: too many open files`  was due to the allowance of limited number of open file descriptors by the operating system. There was no deadline set for opened connections so most of the connections never get closed. In result, the number of opened connections gradually cross the maximum open file descriptors limit and cause panic. 
Now with connection timeout  =  `72 second`, number of opened connection will never reach the open file descriptor limit. 