### PR TITLE
Added full support for TELNET proxy

### DIFF
--- a/examples/proxy_telnet.md
+++ b/examples/proxy_telnet.md
@@ -1,0 +1,19 @@
+# TELNET Proxy
+
+Glutton support for proxying TELNET connections. Work as MITM between attacker and TELNET server and logs every thing travelling through the connection. So attacker will have a real machine with no logging agent inside and it will be very harder for attacker to figerprint the honeypot. Glutton only support integration of one TELNET server.
+
+## Integration
+
+Note the IP address and port of destination TELNET server and register in Glutton with help of `rules/rules.yaml` file. 
+Edit the follwing rules and past it into `rules/rules.yaml`:  
+
+```
+  - match: tcp dst port 23
+    type: conn_handler
+    name: proxy_telnet
+    target: tcp://<IP Address>:<Port>
+```
+
+Every connection on port `23` TELNET server at `target` IP address.
+
+Note: Rules are matched against packet from top to bottom so first matching rule will executed. Make sure you have placed the rule at right position. 

--- a/glutton.go
+++ b/glutton.go
@@ -27,6 +27,7 @@ type Glutton struct {
 	rules            []*freki.Rule
 	producer         *producer.Config
 	protocolHandlers map[string]protocolHandlerFunc
+	telnetProxy      *telnetProxy
 	sshProxy         *sshProxy
 	ctx              context.Context
 	cancel           context.CancelFunc
@@ -177,7 +178,15 @@ func (g *Glutton) registerHandlers() {
 				}
 				rule.Target = handler
 				break
-
+			case "proxy_telnet":
+				handler = rule.Name
+				err := g.NewTelnetProxy(rule.Target)
+				if err != nil {
+					g.logger.Error(fmt.Sprint("[telnet.prxy] failed to initialize TELNET proxy"))
+					continue
+				}
+				rule.Target = handler
+				break
 			default:
 				handler = rule.Target
 				break

--- a/logger.go
+++ b/logger.go
@@ -10,7 +10,6 @@ import (
 )
 
 func initLogger(logPath *string, id string, debug *string) (*zap.Logger, error) {
-
 	var cfg zap.Config
 	if !com.IsDir(*logPath) {
 		cfg = zap.NewProductionConfig()

--- a/protocols.go
+++ b/protocols.go
@@ -50,7 +50,9 @@ func (g *Glutton) mapProtocolHandlers() {
 	g.protocolHandlers["proxy_ssh"] = func(ctx context.Context, conn net.Conn) (err error) {
 		return g.sshProxy.handle(ctx, conn)
 	}
-
+	g.protocolHandlers["proxy_telnet"] = func(ctx context.Context, conn net.Conn) (err error) {
+		return g.telnetProxy.handle(ctx, conn)
+	}
 	g.protocolHandlers["default"] = func(ctx context.Context, conn net.Conn) (err error) {
 		// TODO: remove 'context.TODO()' when handler code start using context.
 		ctx = context.TODO()

--- a/protocols.go
+++ b/protocols.go
@@ -69,7 +69,7 @@ func (g *Glutton) closeOnShutdown(conn net.Conn, done <-chan struct{}) {
 	select {
 	case <-g.ctx.Done():
 		if err := conn.Close(); err != nil {
-			g.logger.Error(fmt.Sprintf("[glutton  ]  error: %v", err))
+			g.logger.Error(fmt.Sprintf("[glutton  ]  error on close: %v", err))
 		}
 		return
 	case <-done:

--- a/proxy_telnet.go
+++ b/proxy_telnet.go
@@ -116,11 +116,7 @@ func (t *telnetProxy) handle(ctx context.Context, conn net.Conn) (err error) {
 				break
 			}
 			if len(strings.Trim(msg, " ")) > 0 {
-<<<<<<< HEAD
 				t.logger.Info(fmt.Sprintf("[telnet proxy  ]   Info: Sending: %d bytes(s) to Server, Bytes:\n %s", len(string(msg)), string(msg)))
-=======
-				t.logger.Info(fmt.Sprintf("[telnet proxy  ]   Info: Sending: %d bytes(s) to Server, Bytes:\n %s", len(string(msg)), string(msg)))
->>>>>>> f12c33ff866cea847842e28de431be10242c3926
 				fmt.Println(fmt.Sprintf("[telnet proxy ]  Info: Sending: %d bytes(s) to Server", len(string(msg))))
 			}
 		}

--- a/proxy_telnet.go
+++ b/proxy_telnet.go
@@ -80,7 +80,7 @@ func (t *telnetProxy) handle(ctx context.Context, conn net.Conn) (err error) {
 			t.logger.Info(fmt.Sprintf("[telnet proxy  ]   Info: Recieved: %d bytes(s) from Server. Bytes: %s", len(string(reply)), string(reply)))
 			err = writeMsg(conn, string(reply), g)
 			if(err != nil) {
-				t.logger.Error(fmt.Sprintf("[telnet proxy] Error: %v", err)
+				t.logger.Error(fmt.Sprintf("[telnet proxy] Error: %v", err))
 				break
 			}
 		}
@@ -98,7 +98,7 @@ func (t *telnetProxy) handle(ctx context.Context, conn net.Conn) (err error) {
 			}
 			msg, err := readMsg(conn, g)
 			if err != nil {
-				t.logger.Error(fmt.Sprintf("[telnet proxy] Error: %v", err)
+				t.logger.Error(fmt.Sprintf("[telnet proxy] Error: %v", err))
 				break
 			}
 			_, err = hconn.Write([]byte(msg))

--- a/proxy_telnet.go
+++ b/proxy_telnet.go
@@ -1,0 +1,127 @@
+package glutton
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/reiver/go-telnet"
+	log "go.uber.org/zap"
+)
+
+//telnetProxy Struct
+type telnetProxy struct {
+	logger      *log.Logger
+	curConn     net.Conn
+	proxyclient *telnet.Client
+	hostconn    *telnet.Conn
+	glutton     *Glutton
+	host        string
+}
+
+//NewTelnetProxy Create a new Telnet Proxy Session
+func (g *Glutton) NewTelnetProxy(destinationURL string) (err error) {
+
+	t := &telnetProxy{
+		logger:  g.logger,
+		glutton: g,
+	}
+
+	dest, err := url.Parse(destinationURL)
+	if err != nil {
+		t.logger.Error("[telnet.prxy] failed to parse destination address, check config.yaml")
+		fmt.Println(fmt.Sprintf("[telnet.prxy ]   failed to parse destination address, check config.yaml"))
+		return err
+	}
+	t.logger.Info("[telnet proxy] " + dest.Host)
+	t.host = dest.Host
+	g.telnetProxy = t
+	return
+}
+
+//handle Telnet Proxy handler
+func (t *telnetProxy) handle(ctx context.Context, conn net.Conn) (err error) {
+	ended := false
+	g := t.glutton
+	tcpAddr, err := net.ResolveTCPAddr("tcp", t.host)
+	if err != nil {
+		println("ResolveTCPAddr failed:", err.Error())
+		return
+	}
+	hconn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		t.logger.Error(fmt.Sprintf("[telnet proxy  ]  Connection error: %v", err))
+		fmt.Println(fmt.Sprintf("[telnet proxy ]  Coonection error: %v", err))
+		return
+	}
+	n := 0
+	go func() {
+		defer func() {
+			ended = true
+			conn.Close()
+			hconn.Close()
+		}()
+		for {
+			if ended == true || hconn == nil || conn == nil {
+				break
+			}
+			reply := make([]byte, 8*1024)
+			n, err = hconn.Read(reply)
+			if err != nil {
+				if err == io.EOF {
+					t.logger.Error(fmt.Sprintf("[telnet proxy  ]   Connection closed by Server"))
+					fmt.Println(fmt.Sprintf("[telnet proxy ]  Connection closed by Server"))
+					break
+				}
+				t.logger.Error(fmt.Sprintf("[telnet proxy  ]   error: %v", err))
+				fmt.Println(fmt.Sprintf("[telnet proxy ]  error: %v", err))
+				break
+			}
+
+			t.logger.Info(fmt.Sprintf("[telnet proxy  ]   Info: Recieved: %d bytes(s) from Server. Bytes: %s", len(string(reply)), string(reply)))
+			fmt.Println(fmt.Sprintf("[telnet proxy ]  Info: Recieved: %d bytes(s) from Server", len(string(reply))))
+			writeMsg(conn, string(reply), g)
+		}
+		return
+	}()
+	go func() {
+		defer func() {
+			ended = true
+			conn.Close()
+			hconn.Close()
+		}()
+		for {
+			if ended == true || hconn == nil || conn == nil {
+				return
+			}
+			msg, err := readMsg(conn, g)
+			if err != nil {
+				break
+			}
+			_, err = hconn.Write([]byte(msg))
+			if err != nil {
+				if err == io.EOF {
+					t.logger.Error(fmt.Sprintf("[telnet proxy  ]   Connection closed by Server"))
+					fmt.Println(fmt.Sprintf("[telnet proxy ]  Connection closed by Server"))
+					break
+				}
+				t.logger.Error(fmt.Sprintf("[telnet proxy  ]   Error: %v", err))
+				fmt.Println(fmt.Sprintf("[telnet proxy ]  Error: %v", err))
+				break
+			}
+			if msg == "^C" {
+				break
+			}
+			if len(strings.Trim(msg, " ")) > 0 {
+				t.logger.Info(fmt.Sprintf("[telnet proxy  ]   Info: Sending: %d bytes(s) to Server, Bytes:\n %s", len(string(msg)), string(msg)))
+				fmt.Println(fmt.Sprintf("[telnet proxy ]  Info: Sending: %d bytes(s) to Server", len(string(msg))))
+			}
+		}
+		return
+	}()
+
+	return
+}


### PR DESCRIPTION
Added a struct for telnet Proxy and added an instance of it in the Gutton struct. Also registered it as a handler in glutton.go
Added an example for the rule of telnet_proxy in examples folder. 
In protocol .go the telnet handler is called same as other handlers are called.