### PR TITLE
fixed UUID, removed connection count for issue #120

### DIFF
--- a/glutton.go
+++ b/glutton.go
@@ -131,7 +131,7 @@ func (g *Glutton) makeID() error {
 		return err
 	}
 	if f, err := os.OpenFile(filePath, os.O_RDWR, 0644); os.IsNotExist(err) {
-		g.id = uuid.NewV4()
+		g.id, _ = uuid.NewV4()
 		errWrite := ioutil.WriteFile(filePath, g.id.Bytes(), 0644)
 		if err != nil {
 			return errWrite

--- a/protocols/smb/smb.go
+++ b/protocols/smb/smb.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 type SMBHeader struct {
@@ -233,7 +233,7 @@ func MakeComTransaction2Error(header SMBHeader) ([]byte, error) {
 }
 
 func MakeNegotiateProtocolResponse(header SMBHeader) ([]byte, error) {
-	id := uuid.NewV4()
+	id, _ := uuid.NewV4()
 	smb := NegotiateProtocolResponse{}
 	smb.Header.Protocol = header.Protocol
 	smb.Header.Command = header.Command

--- a/system.go
+++ b/system.go
@@ -32,8 +32,8 @@ func (g *Glutton) startMonitor(quit chan struct{}) {
 				openFiles := countOpenFiles()
 				runningRoutines := countRunningRoutines()
 				g.logger.Info(fmt.Sprintf(
-					"[system  ] running Go routines: %d, open files: %d, open connections: %d",
-					openFiles, runningRoutines, g.processor.Connections.Length(),
+					"[system  ] running Go routines: %d, open files: %d",
+					openFiles, runningRoutines,
 				))
 			case <-quit:
 				g.logger.Info("[system  ] Monitoring stopped..")


### PR DESCRIPTION
Addressing issue #120

It seems satori/go.uuid made a breaking change that caused the UUID issue. The connection count was removed in a prior commit but later re-added, this will remove it again.