### PR TITLE
fixed multiple-value into single-value error

### DIFF
--- a/glutton.go
+++ b/glutton.go
@@ -131,11 +131,14 @@ func (g *Glutton) makeID() error {
 		return err
 	}
 	if f, err := os.OpenFile(filePath, os.O_RDWR, 0644); os.IsNotExist(err) {
-		g.id = uuid.NewV4()
+        var err2 error
+        g.id, err2 = uuid.NewV4()
 		errWrite := ioutil.WriteFile(filePath, g.id.Bytes(), 0644)
 		if err != nil {
 			return errWrite
-		}
+        } else if err2 != nil {
+            return err2
+        }
 	} else {
 		if err != nil {
 			return err

--- a/protocols/smb/smb.go
+++ b/protocols/smb/smb.go
@@ -233,7 +233,10 @@ func MakeComTransaction2Error(header SMBHeader) ([]byte, error) {
 }
 
 func MakeNegotiateProtocolResponse(header SMBHeader) ([]byte, error) {
-	id := uuid.NewV4()
+	id, err := uuid.NewV4()
+    if err != nil {
+        return nil, err
+    }
 	smb := NegotiateProtocolResponse{}
 	smb.Header.Protocol = header.Protocol
 	smb.Header.Command = header.Command


### PR DESCRIPTION
The NewV4 method returns an error which wasn't previously accounted for