### PR TITLE
glutton.go: Added timeout variable to conf.yml

### DIFF
--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -15,3 +15,7 @@ producers:
     ident: ident
     auth: auth
     channel: test
+
+timeout: 45
+  
+

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -16,6 +16,6 @@ producers:
     auth: auth
     channel: test
 
-timeout: 45
+conn_timeout: 45
   
 

--- a/glutton.go
+++ b/glutton.go
@@ -222,7 +222,8 @@ func (g *Glutton) registerHandlers() {
 
 				done := make(chan struct{})
 				go g.closeOnShutdown(conn, done)
-				if err = conn.SetDeadline(time.Now().Add(45 * time.Second)); err != nil {
+				timeoutDuration := viper.GetInt("timeout")
+				if err = conn.SetDeadline(time.Now().Add(time.Duration(timeoutDuration) * time.Second)); err != nil {
 					return err
 				}
 				ctx := g.contextWithTimeout(72)

--- a/glutton.go
+++ b/glutton.go
@@ -222,8 +222,7 @@ func (g *Glutton) registerHandlers() {
 
 				done := make(chan struct{})
 				go g.closeOnShutdown(conn, done)
-				timeoutDuration := viper.GetInt("timeout")
-				if err = conn.SetDeadline(time.Now().Add(time.Duration(timeoutDuration) * time.Second)); err != nil {
+				if err = conn.SetDeadline(time.Now().Add(time.Duration(viper.GetInt("conn_timeout")) * time.Second)); err != nil {
 					return err
 				}
 				ctx := g.contextWithTimeout(72)


### PR DESCRIPTION
Made the `conn.setDeadline` configurable so that it
can be configured by the user.

Closes https://github.com/mushorg/glutton/issues/84