### PR TITLE
app/server.go: Set var-dir on startup

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -53,7 +53,8 @@ func main() {
 	pflag.StringP("confpath", "c", "config/", "Configuration file path")
 	pflag.BoolP("debug", "d", false, "Enable debug mode")
 	pflag.Bool("version", false, "Print version")
-
+    pflag.Bool("var-dir","v","/var/lib/glutton", "Set var-dir")
+	
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)
 

--- a/app/server.go
+++ b/app/server.go
@@ -53,8 +53,8 @@ func main() {
 	pflag.StringP("confpath", "c", "config/", "Configuration file path")
 	pflag.BoolP("debug", "d", false, "Enable debug mode")
 	pflag.Bool("version", false, "Print version")
-    pflag.Bool("var-dir","v","/var/lib/glutton", "Set var-dir")
-	
+	pflag.String("var-dir", "/var/lib/glutton", "Set var-dir")
+
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)
 

--- a/glutton.go
+++ b/glutton.go
@@ -50,7 +50,6 @@ func (g *Glutton) initConfig() (err error) {
 func New() (g *Glutton, err error) {
 	g = &Glutton{}
 	g.protocolHandlers = make(map[string]protocolHandlerFunc, 0)
-	viper.SetDefault("var-dir", "/var/lib/glutton")
 	if err = g.makeID(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Created var-dir pflag in `app/server.go` so
that it did not have to be set via viper
in `glutton.go`

Closes: https://github.com/mushorg/glutton/issues/134