### PR TITLE
Set dest_port to string

### DIFF
--- a/glutton.go
+++ b/glutton.go
@@ -223,7 +223,7 @@ func (g *Glutton) registerHandlers() {
 					return err
 				}
 				if matched {
-					g.Logger.Info("IP from a known scanner", zap.String("host", host), zap.String("scanner", name), zap.Uint16("dest_port", uint16(md.TargetPort)))
+					g.Logger.Info("IP from a known scanner", zap.String("host", host), zap.String("scanner", name), zap.String("dest_port", strconv.Itoa(int(md.TargetPort))))
 					return nil
 				}
 


### PR DESCRIPTION
Set dest_port to string in scanner log entries to match the dest_port format in normal connection logs (L211).