### PR TITLE
fix double msg in ftp and telnet - FIX 148

### DIFF
--- a/protocols/ftp.go
+++ b/protocols/ftp.go
@@ -33,7 +33,7 @@ func readFTP(conn net.Conn, logger Logger, h Honeypot) (string, error) {
 		zap.String("dest_port", strconv.Itoa(int(md.TargetPort))),
 		zap.String("src_ip", host),
 		zap.String("src_port", port),
-		zap.String("msg", fmt.Sprintf("%q", msg)),
+		zap.String("message", fmt.Sprintf("%q", msg)),
 		zap.String("handler", "ftp"),
 	)
 	return msg, err

--- a/protocols/telnet.go
+++ b/protocols/telnet.go
@@ -85,7 +85,7 @@ func WriteTelnetMsg(conn net.Conn, msg string, logger Logger, h Honeypot) error 
 	logger.Info(
 		"telnet send",
 		zap.String("handler", "telnet"),
-		zap.String("msg", fmt.Sprintf("%q", msg)),
+		zap.String("message", fmt.Sprintf("%q", msg)),
 		zap.String("direction", "send"),
 		zap.String("dest_port", dstPort),
 		zap.String("src_ip", host),
@@ -111,7 +111,7 @@ func ReadTelnetMsg(conn net.Conn, logger Logger, h Honeypot) (string, error) {
 	logger.Info(
 		"telnet recv",
 		zap.String("handler", "telnet"),
-		zap.String("msg", fmt.Sprintf("%q", msg)),
+		zap.String("message", fmt.Sprintf("%q", msg)),
 		zap.String("direction", "recv"),
 		zap.String("dest_port", strconv.Itoa(int(md.TargetPort))),
 		zap.String("src_ip", host),


### PR DESCRIPTION
This pull request attempts to fix the logging issue described here: https://github.com/mushorg/glutton/issues/148

The logged message for FTP and telnet is renamed to `message` to make it easier for SIEM systems (OpenSearch / ELK / Wazuh) to ingest data directly from glutton. 

Previously, this was not possible because telnet and FTP had two `msg` entries per logged line. 