### PR TITLE
Fix `ports.glutton_server` config parsing

### DIFF
--- a/glutton.go
+++ b/glutton.go
@@ -42,7 +42,7 @@ func (g *Glutton) initConfig() error {
 		return err
 	}
 	// If no config is found, use the defaults
-	viper.SetDefault("glutton_server", 5000)
+	viper.SetDefault("ports.glutton_server", 5000)
 	viper.SetDefault("max_tcp_payload", 4096)
 	viper.SetDefault("rules_path", "rules/rules.yaml")
 	g.Logger.Debug("configuration loaded successfully", zap.String("reporter", "glutton"))
@@ -83,7 +83,7 @@ func (g *Glutton) Init() error {
 	ctx := context.Background()
 	g.ctx, g.cancel = context.WithCancel(ctx)
 
-	gluttonServerPort := uint(viper.GetInt("glutton_server"))
+	gluttonServerPort := uint(viper.GetInt("ports.glutton_server"))
 
 	// Initiate the freki processor
 	var err error


### PR DESCRIPTION
[Current example config](https://github.com/mushorg/glutton/blob/031fcdfa95f3c9a790219ffbac7a47b7856558a8/config/config.yaml#L2) does not work because in the code prefix `ports` is not used. This change adds the prefix. Adding the prefix makes the config name more readable.