### PR TITLE
Fix ssh proxy

### DIFF
--- a/proxy_ssh.go
+++ b/proxy_ssh.go
@@ -91,6 +91,7 @@ func (s *sshProxy) initConf(dest string) error {
 				Auth: []ssh.AuthMethod{
 					ssh.Password(string(pass)),
 				},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 			}
 
 			n := 0


### PR DESCRIPTION
Without `HostKeyCallback`, ssh proxy never successfully
connects to the remote ssh. [According to documentation](https://pkg.go.dev/golang.org/x/crypto/ssh#ClientConfig), this callback is required.

