### PR TITLE
#166: Added support for the interface name in the config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ NAME := glutton
 BUILDSTRING := $(shell git log --pretty=format:'%h' -n 1)
 VERSIONSTRING := $(NAME) version $(VERSION)+$(BUILDSTRING)
 BUILDDATE := $(shell date -u -Iseconds)
-CONFIG_FILE=config/config.yaml
 
 LDFLAGS := "-X \"main.VERSION=$(VERSIONSTRING)\" -X \"main.BUILDDATE=$(BUILDDATE)\""
 

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,7 @@ clean:
 	rm -rf bin/
 
 run: build
-	@if grep -q 'interface:' config.yaml; then \
-		INTERFACE=$$(grep 'interface:' config.yaml | awk '{print $$2}'); \
-	else \
-		INTERFACE=eth0; \
-	fi; \
-	sudo bin/server -c config.yaml -i $$INTERFACE
-
+	sudo bin/server
 docker:
 	docker build -t glutton .
 	docker run --rm --cap-add=NET_ADMIN -it glutton

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,12 @@ clean:
 	rm -rf bin/
 
 run: build
-	sudo bin/server -c config.yaml
+	@if grep -q 'interface:' config.yaml; then \
+		INTERFACE=$$(grep 'interface:' config.yaml | awk '{print $$2}'); \
+	else \
+		INTERFACE=eth0; \
+	fi; \
+	sudo bin/server -c config.yaml -i $$INTERFACE
 
 docker:
 	docker build -t glutton .

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 	rm -rf bin/
 
 run: build
-	sudo bin/server -i eth0
+	sudo bin/server -c config.yaml
 
 docker:
 	docker build -t glutton .

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ BUILDSTRING := $(shell git log --pretty=format:'%h' -n 1)
 VERSIONSTRING := $(NAME) version $(VERSION)+$(BUILDSTRING)
 BUILDDATE := $(shell date -u -Iseconds)
 CONFIG_FILE=config/config.yaml
-INTERFACE=$(shell grep 'interface:' $(CONFIG_FILE) | awk '{print $$2}')
 
 LDFLAGS := "-X \"main.VERSION=$(VERSIONSTRING)\" -X \"main.BUILDDATE=$(BUILDDATE)\""
 
@@ -32,7 +31,7 @@ clean:
 	rm -rf bin/
 
 run: build
-	sudo bin/server -i $(INTERFACE)
+	sudo bin/server -i eth0
 
 docker:
 	docker build -t glutton .

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ NAME := glutton
 BUILDSTRING := $(shell git log --pretty=format:'%h' -n 1)
 VERSIONSTRING := $(NAME) version $(VERSION)+$(BUILDSTRING)
 BUILDDATE := $(shell date -u -Iseconds)
+CONFIG_FILE=config/config.yaml
+INTERFACE=$(shell grep 'interface:' $(CONFIG_FILE) | awk '{print $$2}')
 
 LDFLAGS := "-X \"main.VERSION=$(VERSIONSTRING)\" -X \"main.BUILDDATE=$(BUILDDATE)\""
 
@@ -30,7 +32,7 @@ clean:
 	rm -rf bin/
 
 run: build
-	sudo bin/server -i eth0
+	sudo bin/server -i $(INTERFACE)
 
 docker:
 	docker build -t glutton .

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Arch:
 pacman -S gcc libpcap iptables
 ```
 
+Fedora:
+```
+sudo dnf install gcc libpcap-devel iptables
+```
+
 Build glutton:
 ```
 make build
@@ -23,7 +28,7 @@ make build
 
 To run/test glutton:
 ```
-bin/server
+sudo bin/server
 ```
 
 To get this to work on WSL, use this kernel: https://github.com/Locietta/xanmod-kernel-WSL2

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,3 @@
-interface: eth0
-tcpPort: 8080
-udpPort: 8081
-sshPort: 2222
-
 ports:
   tcp: 5000
   udp: 5001
@@ -11,6 +6,8 @@ ports:
 rules_path: config/rules.yaml
 
 addresses: ["1.2.3.4", "5.4.3.2"]
+
+interface: eth0
 
 producers:
   enabled: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,8 @@
+interface: eth0
+tcpPort: 8080
+udpPort: 8081
+sshPort: 2222
+
 ports:
   tcp: 5000
   udp: 5001

--- a/glutton.go
+++ b/glutton.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -45,10 +44,6 @@ type Glutton struct {
 var defaultRules []byte
 
 func (g *Glutton) initConfig() error {
-	var interfaceName string
-	flag.StringVar(&interfaceName, "i", "", "Network interface name")
-	flag.Parse()
-
 	viper.SetConfigName("config")
 	viper.AddConfigPath(viper.GetString("confpath"))
 	if _, err := os.Stat(viper.GetString("confpath")); !os.IsNotExist(err) {

--- a/glutton.go
+++ b/glutton.go
@@ -57,15 +57,13 @@ func (g *Glutton) initConfig() error {
 		}
 	}
 	// If no config is found, use the defaults
-	viper.SetDefault("ports.ttcp", 5000)
+	viper.SetDefault("ports.tcp", 5000)
 	viper.SetDefault("ports.udp", 5001)
 	viper.SetDefault("ports.ssh", 22)
 	viper.SetDefault("max_tcp_payload", 4096)
 	viper.SetDefault("conn_timeout", 45)
 	viper.SetDefault("rules_path", "rules/rules.yaml")
 	viper.SetDefault("interface", "eth0") // Default interface name
-
-	interfaceName = viper.GetString("interface")
 
 	g.Logger.Debug("configuration set successfully", slog.String("reporter", "glutton"))
 	return nil

--- a/glutton.go
+++ b/glutton.go
@@ -49,7 +49,7 @@ var (
 var defaultRules []byte
 
 func init() {
-	flag.StringVar(&interfaceName, "interface", "", "Network interface name")
+	flag.StringVar(&interfaceName, "i", "", "Network interface name")
 	flag.Parse()
 }
 


### PR DESCRIPTION
Hey @glaslos,

Reffering to issue #166 
I've made the necessary changes including adding new field to the configuration file for specifying the interface name.
Here’s how you can use the command:
```
sudo bin/server -i <interface name>
```
Example use case: `sudo bin/server -i wlan0`

By default, it will use `eth0`.

Additionally, I've included instructions for installing and running the project on Fedora. Since the `bin/server` command requires sudo privileges, I’ve also tried upgrading the README.md file to reflect these changes accordingly.

I would greatly appreciate your feedback on any changes or further modifications needed, I will be glad to do so!
Thank you,
Tank0nf.