### PR TITLE
#166 : Added support for the interface name in the config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 	rm -rf bin/
 
 run: build
-	sudo bin/server -i eth0
+	sudo bin/server $(ARGS)
 
 docker:
 	docker build -t glutton .

--- a/app/server.go
+++ b/app/server.go
@@ -44,6 +44,7 @@ func main() {
 
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)
+	viper.BindPFlag("network.interface", pflag.Lookup("interface"))
 
 	if viper.IsSet("ssh") {
 		viper.Set("ports.ssh", viper.GetInt("ssh"))

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,6 @@
+network:
+  interface: eth0
+  
 ports:
   tcp: 5000
   udp: 5001


### PR DESCRIPTION
fixes #166 
**Changes Made**
1. Added `network.interface` to `config/config.yaml` with `eth0` as the default.
2. Removed hardcoded `-i eth0` in favor of dynamic `ARGS` input.

      for default interface->`make run`
      for override interface->`make run ARGS="--interface=enxa0cec8f8646e"`

3. Added flag binding in `main.go` to prioritize CLI flags over config.

@glaslos I would be happy to know if there are any changes needed to be done in my PR