### PR TITLE
feat: drop root user to nobody user

### DIFF
--- a/glutton.go
+++ b/glutton.go
@@ -236,10 +236,7 @@ func (g *Glutton) tcpListen() {
 	}
 }
 
-// Start the listener, this blocks for new connections
-func (g *Glutton) Start() error {
-	g.startMonitor()
-
+func (g *Glutton) SetupIPTableRules() error {
 	sshPort := viper.GetUint32("ports.ssh")
 	if err := setTProxyIPTables(viper.GetString("interface"), g.publicAddrs[0].String(), "tcp", uint32(g.Server.tcpPort), sshPort); err != nil {
 		return err
@@ -248,6 +245,12 @@ func (g *Glutton) Start() error {
 	if err := setTProxyIPTables(viper.GetString("interface"), g.publicAddrs[0].String(), "udp", uint32(g.Server.udpPort), sshPort); err != nil {
 		return err
 	}
+	return nil
+}
+
+// Start the listener, this blocks for new connections
+func (g *Glutton) Start() error {
+	g.startMonitor()
 
 	wg := &sync.WaitGroup{}
 


### PR DESCRIPTION
This pull request addresses the issue of root user privileges by dropping them and assigning the "nobody" user.  The original problem stemmed from the SSH traffic re-routing. To resolve this, I've encapsulated the iptables rules for SSH traffic re-routing within a dedicated method.  Root privileges are now dropped immediately after these iptables rules are configured.

cc @glaslos 