### PR TITLE
Added handler for HTTP2/PRI

### DIFF
--- a/protocols/protocols.go
+++ b/protocols/protocols.go
@@ -75,7 +75,7 @@ func MapTCPProtocolHandlers(log interfaces.Logger, h interfaces.Honeypot) map[st
 			return nil
 		}
 		// poor mans check for HTTP request
-		httpMap := map[string]bool{"GET ": true, "POST": true, "HEAD": true, "OPTI": true, "CONN": true}
+		httpMap := map[string]bool{"GET ": true, "POST": true, "HEAD": true, "OPTI": true, "CONN": true,"PRI": true}
 		if _, ok := httpMap[strings.ToUpper(string(snip))]; ok {
 			return tcp.HandleHTTP(ctx, bufConn, md, log, h)
 		}


### PR DESCRIPTION
fixes #159 

**Key Changes**

1. Added `PRI` in `protocols.go` to `httpMap` such that it detects HTTP/2 connections
2. Modified `HandleHTTP` function in `tcp/http.go` 
3. In the handler it reads the first 24 bytes (exact length of HTTP/2 client preface: `PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n`) and checks if data matches with HTTP/2 preface
4. The server then responds with a minimal **settings frame** .

If there are any changes to be made I am ready to modify them.