### PR TITLE
Adds protocol handler for MongoDB

### DIFF
--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -32,10 +32,12 @@ rules:
   - match: tcp dst port 3260
     type: conn_handler
     target: iscsi
+  - match: tcp dst port 27017
+    type: conn_handler
+    target: mongodb
   - match: tcp
     type: conn_handler
     target: tcp
   - match: udp
     type: conn_handler
     target: udp
-    

--- a/protocols/protocols.go
+++ b/protocols/protocols.go
@@ -3,6 +3,7 @@ package protocols
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"net"
 	"strings"
 
@@ -68,6 +69,9 @@ func MapTCPProtocolHandlers(log interfaces.Logger, h interfaces.Honeypot) map[st
 	protocolHandlers["adb"] = func(ctx context.Context, conn net.Conn, md connection.Metadata) error {
 		return tcp.HandleADB(ctx, conn, md, log, h)
 	}
+	protocolHandlers["mongodb"] = func(ctx context.Context, conn net.Conn, md connection.Metadata) error {
+		return tcp.HandleMongoDB(ctx, conn, md, log, h)
+	}
 	protocolHandlers["tcp"] = func(ctx context.Context, conn net.Conn, md connection.Metadata) error {
 		snip, bufConn, err := Peek(conn, 4)
 		if err != nil {
@@ -85,6 +89,35 @@ func MapTCPProtocolHandlers(log interfaces.Logger, h interfaces.Honeypot) map[st
 		// poor mans check for RDP header
 		if bytes.Equal(snip, []byte{0x03, 0x00, 0x00, 0x2b}) {
 			return tcp.HandleRDP(ctx, bufConn, md, log, h)
+		}
+		// poor mans check for MongoDB header (checking msg length and validating opcodes)
+		messageLength := binary.LittleEndian.Uint32(snip)
+		if messageLength > 0 && messageLength <= 48*1024*1024 {
+			moreSample, bufConn, err := Peek(bufConn, 16)
+			if err != nil {
+				if err := conn.Close(); err != nil {
+					log.Error("failed to close connection", producer.ErrAttr(err))
+				}
+				log.Debug("failed to peek connection", producer.ErrAttr(err))
+				return nil
+			}
+			if len(moreSample) == 16 {
+				opCode := binary.LittleEndian.Uint32(moreSample[12:16])
+				validOpCodes := map[uint32]bool{
+					1:    true, // OP_REPLY
+					2001: true, // OP_UPDATE
+					2002: true, // OP_INSERT
+					2004: true, // OP_QUERY
+					2005: true, // OP_GET_MORE
+					2006: true, // OP_DELETE
+					2007: true, // OP_KILL_CURSORS
+					2012: true, // OP_COMPRESSED
+					2013: true, // OP_MSG
+				}
+				if _, ok := validOpCodes[opCode]; ok {
+					return tcp.HandleMongoDB(ctx, bufConn, md, log, h)
+				}
+			}
 		}
 		// fallback TCP handler
 		return tcp.HandleTCP(ctx, bufConn, md, log, h)

--- a/protocols/tcp/mongodb.go
+++ b/protocols/tcp/mongodb.go
@@ -1,0 +1,233 @@
+package tcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+
+	"github.com/mushorg/glutton/connection"
+	"github.com/mushorg/glutton/producer"
+	"github.com/mushorg/glutton/protocols/helpers"
+	"github.com/mushorg/glutton/protocols/interfaces"
+)
+
+type MsgHeader struct {
+	MessageLength int32
+	RequestID     int32
+	ResponseTo    int32
+	OpCode        int32
+}
+
+// OpCode values for the MongoDB wire protocol
+const (
+	OpReply       = 1
+	OpUpdate      = 2001
+	OpInsert      = 2002
+	OpQuery       = 2004
+	OpGetMore     = 2005
+	OpDelete      = 2006
+	OpKillCursors = 2007
+	OpCompressed  = 2012
+	OpMsg         = 2013
+)
+
+var opCodeNames = map[int32]string{
+	OpReply:       "OP_REPLY",
+	OpUpdate:      "OP_UPDATE",
+	OpInsert:      "OP_INSERT",
+	OpQuery:       "OP_QUERY",
+	OpGetMore:     "OP_GET_MORE",
+	OpDelete:      "OP_DELETE",
+	OpKillCursors: "OP_KILL_CURSORS",
+	OpCompressed:  "OP_COMPRESSED",
+	OpMsg:         "OP_MSG",
+}
+
+type parsedMongoDB struct {
+	Direction string    `json:"direction,omitempty"`
+	Header    MsgHeader `json:"header,omitempty"`
+	Payload   []byte    `json:"payload,omitempty"`
+	OpCodeStr string    `json:"opcode_str,omitempty"`
+}
+
+type mongoDBServer struct {
+	events []parsedMongoDB
+	conn   net.Conn
+}
+
+func (s *mongoDBServer) read() ([]byte, error) {
+	// read message header
+	headerBytes := make([]byte, 16)
+	if _, err := io.ReadFull(s.conn, headerBytes); err != nil {
+		return nil, err
+	}
+
+	var header MsgHeader
+	if err := binary.Read(bytes.NewReader(headerBytes), binary.LittleEndian, &header); err != nil {
+		return nil, err
+	}
+
+	// check to prevent excessive mem alloc
+	if header.MessageLength <= 0 || header.MessageLength > 48*1024*1024 {
+		return nil, fmt.Errorf("invalid MongoDB message length: %d", header.MessageLength)
+	}
+
+	fullMessage := make([]byte, header.MessageLength)
+
+	copy(fullMessage, headerBytes)
+
+	if _, err := io.ReadFull(s.conn, fullMessage[16:]); err != nil {
+		return nil, err
+	}
+
+	return fullMessage, nil
+}
+
+// writes a Mongo message to the connection
+func (s *mongoDBServer) write(header MsgHeader, data []byte) error {
+	_, err := s.conn.Write(data)
+	if err != nil {
+		return err
+	}
+
+	s.events = append(s.events, parsedMongoDB{
+		Direction: "write",
+		Header:    header,
+		Payload:   data,
+		OpCodeStr: opCodeNames[header.OpCode],
+	})
+
+	return nil
+}
+
+// creates a basic "ok" response for Mongo queries
+func createOkResponse(requestHeader MsgHeader) (MsgHeader, []byte, error) {
+	buffer := new(bytes.Buffer)
+
+	responseHeader := MsgHeader{
+		MessageLength: 0, // will fill in later
+		RequestID:     requestHeader.RequestID + 1,
+		ResponseTo:    requestHeader.RequestID,
+		OpCode:        OpMsg, // using OP_MSG for responses
+	}
+
+	// write placeholder for header
+	if err := binary.Write(buffer, binary.LittleEndian, responseHeader); err != nil {
+		return responseHeader, nil, err
+	}
+
+	// OP_MSG flags - no special flags set
+	flagBits := uint32(0)
+	if err := binary.Write(buffer, binary.LittleEndian, flagBits); err != nil {
+		return responseHeader, nil, err
+	}
+
+	// section kind 0 (Body)
+	sectionKind := byte(0)
+	if err := binary.Write(buffer, binary.LittleEndian, sectionKind); err != nil {
+		return responseHeader, nil, err
+	}
+
+	// simple document with ok:1
+	document := []byte{
+		0x11, 0x00, 0x00, 0x00, // doc size - 17 bytes
+		0x01, 'o', 'k', 0x00, // "ok" (type double)
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F, // double value 1.0
+		0x00, // terminator
+	}
+
+	if _, err := buffer.Write(document); err != nil {
+		return responseHeader, nil, err
+	}
+
+	response := buffer.Bytes()
+
+	messageLength := int32(len(response))
+	binary.LittleEndian.PutUint32(response[0:4], uint32(messageLength))
+
+	responseHeader.MessageLength = messageLength
+
+	return responseHeader, response, nil
+}
+
+func HandleMongoDB(ctx context.Context, conn net.Conn, md connection.Metadata, logger interfaces.Logger, h interfaces.Honeypot) error {
+	server := &mongoDBServer{
+		events: []parsedMongoDB{},
+		conn:   conn,
+	}
+
+	defer func() {
+		if err := h.ProduceTCP("mongodb", conn, md, helpers.FirstOrEmpty[parsedMongoDB](server.events).Payload, server.events); err != nil {
+			logger.Error("Failed to produce MongoDB event", producer.ErrAttr(err), slog.String("protocol", "mongodb"))
+		}
+
+		if err := conn.Close(); err != nil {
+			logger.Debug("Failed to close MongoDB connection", producer.ErrAttr(err), slog.String("protocol", "mongodb"))
+		}
+	}()
+
+	host, port, err := net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		return fmt.Errorf("failed to split remote address: %w", err)
+	}
+
+	for {
+		if err := h.UpdateConnectionTimeout(ctx, conn); err != nil {
+			logger.Debug("Failed to update connection timeout", producer.ErrAttr(err), slog.String("protocol", "mongodb"))
+			return nil
+		}
+
+		message, err := server.read()
+		if err != nil {
+			if err != io.EOF {
+				logger.Debug("Failed to read MongoDB message", producer.ErrAttr(err), slog.String("protocol", "mongodb"))
+			}
+			break
+		}
+
+		var header MsgHeader
+		if err := binary.Read(bytes.NewReader(message[:16]), binary.LittleEndian, &header); err != nil {
+			logger.Error("Failed to parse MongoDB header", producer.ErrAttr(err), slog.String("protocol", "mongodb"))
+			break
+		}
+
+		server.events = append(server.events, parsedMongoDB{
+			Direction: "read",
+			Header:    header,
+			Payload:   message,
+			OpCodeStr: opCodeNames[header.OpCode],
+		})
+
+		logger.Info(
+			"MongoDB message received",
+			slog.String("dest_port", strconv.Itoa(int(md.TargetPort))),
+			slog.String("src_ip", host),
+			slog.String("src_port", port),
+			slog.String("opcode", opCodeNames[header.OpCode]),
+			slog.Int("message_length", int(header.MessageLength)),
+			slog.Int("request_id", int(header.RequestID)),
+			slog.String("handler", "mongodb"),
+		)
+
+		logger.Debug(fmt.Sprintf("MongoDB payload:\n%s", hex.Dump(message)))
+
+		responseHeader, response, err := createOkResponse(header)
+		if err != nil {
+			logger.Error("Failed to create MongoDB response", producer.ErrAttr(err), slog.String("protocol", "mongodb"))
+			break
+		}
+
+		if err := server.write(responseHeader, response); err != nil {
+			logger.Error("Failed to write MongoDB response", producer.ErrAttr(err), slog.String("protocol", "mongodb"))
+			break
+		}
+	}
+
+	return nil
+}

--- a/protocols/tcp/mongodb_test.go
+++ b/protocols/tcp/mongodb_test.go
@@ -1,0 +1,106 @@
+package tcp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// tests the Mongo response creation function
+func TestCreateOkResponse(t *testing.T) {
+	requestHeader := MsgHeader{
+		MessageLength: 100,
+		RequestID:     12345,
+		ResponseTo:    0,
+		OpCode:        OpMsg,
+	}
+
+	responseHeader, response, err := createOkResponse(requestHeader)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	require.Equal(t, int32(len(response)), responseHeader.MessageLength)
+	require.Equal(t, requestHeader.RequestID+1, responseHeader.RequestID)
+	require.Equal(t, requestHeader.RequestID, responseHeader.ResponseTo)
+	require.Equal(t, int32(OpMsg), responseHeader.OpCode)
+
+	require.Equal(t, int32(len(response)), int32(binary.LittleEndian.Uint32(response[0:4])))
+
+	// check flags - should be 0
+	flags := binary.LittleEndian.Uint32(response[16:20])
+	require.Equal(t, uint32(0), flags)
+
+	// check section type - should be 0 (body)
+	require.Equal(t, byte(0), response[20])
+}
+
+// tests the Mongo handler with a mocked connection
+func TestHandleMongoDB(t *testing.T) {
+	var requestID int32 = 12345
+	var buffer bytes.Buffer
+
+	header := MsgHeader{
+		MessageLength: 39, // length of the entire message including header
+		RequestID:     requestID,
+		ResponseTo:    0,
+		OpCode:        OpMsg,
+	}
+	binary.Write(&buffer, binary.LittleEndian, header)
+
+	// Add flags
+	binary.Write(&buffer, binary.LittleEndian, uint32(0))
+
+	// Body
+	buffer.WriteByte(0)
+
+	// document - {"hello": "mongodb"}
+	docBytes := []byte{
+		0x16, 0x00, 0x00, 0x00, // doc size: 22 bytes
+		0x02, // string type
+		'h', 'e', 'l', 'l', 'o', 0x00,
+		0x08, 0x00, 0x00, 0x00, // string length including null terminator
+		'm', 'o', 'n', 'g', 'o', 'd', 'b', 0x00,
+		0x00, // terminator
+	}
+	buffer.Write(docBytes)
+
+	message := buffer.Bytes()
+	var msgHeader MsgHeader
+	err := binary.Read(bytes.NewReader(message[:16]), binary.LittleEndian, &msgHeader)
+	require.NoError(t, err)
+
+	responseHeader, response, err := createOkResponse(msgHeader)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	require.Equal(t, int32(len(response)), responseHeader.MessageLength)
+	require.Equal(t, requestID+1, responseHeader.RequestID)
+	require.Equal(t, requestID, responseHeader.ResponseTo)
+	require.Equal(t, int32(OpMsg), responseHeader.OpCode)
+
+	var respHeader MsgHeader
+	err = binary.Read(bytes.NewReader(response[:16]), binary.LittleEndian, &respHeader)
+	require.NoError(t, err)
+
+	require.Equal(t, byte(0), response[20])
+
+	// document starts at position 21
+	document := response[21:]
+	require.True(t, len(document) >= 17, "Document too short")
+
+	// first 4 bytes are document size
+	// then type code 0x01 (double) followed by "ok"
+	require.Equal(t, byte(0x01), document[4], "Expected double type code")
+	require.Equal(t, byte('o'), document[5], "Expected 'o' from 'ok' field name")
+	require.Equal(t, byte('k'), document[6], "Expected 'k' from 'ok' field name")
+	require.Equal(t, byte(0x00), document[7], "Expected null terminator")
+
+	// next 8 bytes should be a double with value 1.0
+	expectedValue := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F}
+	require.Equal(t, expectedValue, document[8:16], "Expected double value 1.0")
+
+	// doc should end with a null byte
+	require.Equal(t, byte(0x00), document[16], "Expected document terminator")
+}

--- a/protocols/tcp/mongodb_test.go
+++ b/protocols/tcp/mongodb_test.go
@@ -10,7 +10,7 @@ import (
 
 // tests the Mongo response creation function
 func TestCreateOkResponse(t *testing.T) {
-	requestHeader := MsgHeader{
+	requestHeader := mongoMsgHeader{
 		MessageLength: 100,
 		RequestID:     12345,
 		ResponseTo:    0,
@@ -41,7 +41,7 @@ func TestHandleMongoDB(t *testing.T) {
 	var requestID int32 = 12345
 	var buffer bytes.Buffer
 
-	header := MsgHeader{
+	header := mongoMsgHeader{
 		MessageLength: 39, // length of the entire message including header
 		RequestID:     requestID,
 		ResponseTo:    0,
@@ -67,7 +67,7 @@ func TestHandleMongoDB(t *testing.T) {
 	buffer.Write(docBytes)
 
 	message := buffer.Bytes()
-	var msgHeader MsgHeader
+	var msgHeader mongoMsgHeader
 	err := binary.Read(bytes.NewReader(message[:16]), binary.LittleEndian, &msgHeader)
 	require.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestHandleMongoDB(t *testing.T) {
 	require.Equal(t, requestID, responseHeader.ResponseTo)
 	require.Equal(t, int32(OpMsg), responseHeader.OpCode)
 
-	var respHeader MsgHeader
+	var respHeader mongoMsgHeader
 	err = binary.Read(bytes.NewReader(response[:16]), binary.LittleEndian, &respHeader)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixes #160 

This PR adds support for detecting and responding to MongoDB connection attempts.

Changes:
- Added a new protocol handler for MongoDB (`protocols/tcp/mongodb.go`)
- Added tests for the MongoDB handler (`protocols/tcp/mongodb_test.go`)
- Updated protocol handler mapping in `protocols/protocols.go`
- Added a rule for MongoDB connections in `config/rules.yaml`

I have referred to the MongoDB Wire Protocol from their documentation which can be found [here](https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/). I've taken the message header format and the Opcodes from here.

The implementation includes unit tests for both the response creation function and the handler itself with mocked dependencies. The tests verify that the handler correctly processes Mongo protocol messages and generates valid responses.

The handler in action:
on running `mongo --host localhost --port 5000`

<img width="929" alt="image" src="https://github.com/user-attachments/assets/818704dc-c29a-4993-8202-ea828d96ceca" />