### PR TITLE
Fixed Setup Documentation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -50,7 +50,7 @@ This will compile the project and place the server binary in the `bin/` director
 ```bash
 bin/server --version
 ```
-Replace `<network_interface>` (e.g., `eth0`) with the interface you want to monitor. You should see output similar to:
+You should see output similar to:
 
 ```bash
   _____ _       _   _


### PR DESCRIPTION
Removed a misplaced line in the [Testing the Installation](https://go-glutton.readthedocs.io/en/latest/setup/#testing-the-installation) section in the setup docs.
![image](https://github.com/user-attachments/assets/f9c5db2d-4e0d-4250-8a74-7eccfafbaa91)
