### PR TITLE
test: fix TCP port collisions using ephemeral listeners

### DIFF
--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -10,26 +10,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testck = CKey([2]uint64{9580489724559085892, 13327978790310486453})
+var localhost1234Key = CKey([2]uint64{9580489724559085892, 13327978790310486453})
+
+func testTCPConn(t *testing.T) (net.Conn, CKey) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NotNil(t, ln)
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	conn, err := net.Dial(ln.Addr().Network(), ln.Addr().String())
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	host, port, err := net.SplitHostPort(conn.RemoteAddr().String())
+	require.NoError(t, err)
+	key, err := NewConnKeyByString(host, port)
+	require.NoError(t, err)
+
+	return conn, key
+}
 
 func TestNewConnKeyByString(t *testing.T) {
 	ck, err := NewConnKeyByString("127.0.0.1", "1234")
 	require.NoError(t, err)
-	require.Equal(t, testck, ck)
+	require.Equal(t, localhost1234Key, ck)
 }
 
 func TestNewConnKeyFromNetConn(t *testing.T) {
-	ln, err := net.Listen("tcp4", "127.0.0.1:1234")
-	require.NoError(t, err)
-	require.NotNil(t, ln)
-	defer ln.Close()
-	conn, err := net.Dial(ln.Addr().Network(), ln.Addr().String())
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	defer conn.Close()
+	conn, expected := testTCPConn(t)
 	ck, err := NewConnKeyFromNetConn(conn)
 	require.NoError(t, err)
-	require.Equal(t, testck, ck)
+	require.Equal(t, expected, ck)
 }
 
 func TestNewConnTable(t *testing.T) {
@@ -43,26 +61,19 @@ func TestRegister(t *testing.T) {
 	m1, err := table.Register("127.0.0.1", "1234", uint16(targetPort), &rules.Rule{})
 	require.NoError(t, err)
 	require.NotNil(t, m1)
-	m2 := table.Get(testck)
+	m2 := table.Get(localhost1234Key)
 	require.NotNil(t, m1)
 	require.Equal(t, targetPort, int(m2.TargetPort))
 	require.Equal(t, m1, m2)
 }
 
 func TestRegisterConn(t *testing.T) {
-	ln, err := net.Listen("tcp4", "127.0.0.1:1234")
-	require.NoError(t, err)
-	require.NotNil(t, ln)
-	defer ln.Close()
-	conn, err := net.Dial(ln.Addr().Network(), ln.Addr().String())
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	defer conn.Close()
+	conn, ck := testTCPConn(t)
 	table := New(context.Background())
 	md, err := table.RegisterConn(conn, &rules.Rule{Target: "tcp"})
 	require.NoError(t, err)
 	require.NotNil(t, md)
-	m := table.Get(testck)
+	m := table.Get(ck)
 	require.NotNil(t, m)
 	require.Equal(t, "tcp", m.Rule.Target)
 }
@@ -74,6 +85,6 @@ func TestFlushOlderThan(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, md)
 	table.FlushOlderThan(time.Duration(0))
-	m := table.Get(testck)
+	m := table.Get(localhost1234Key)
 	require.Empty(t, m)
 }

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -24,11 +24,11 @@ func TestProducerLog(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, p)
 
-	l, err := net.Listen("tcp", ":1234")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	require.NotNil(t, l)
 	defer l.Close()
-	conn, err := net.Dial("tcp", ":1234")
+	conn, err := net.Dial(l.Addr().Network(), l.Addr().String())
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 	md := connection.Metadata{

--- a/protocols/protocols_test.go
+++ b/protocols/protocols_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 func testConn(t *testing.T) (net.Conn, func() error) {
-	l, err := net.Listen("tcp", ":1235")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	require.NotNil(t, l)
-	conn, err := net.Dial("tcp", ":1235")
+	conn, err := net.Dial(l.Addr().Network(), l.Addr().String())
 	require.NoError(t, err)
 	err = conn.SetDeadline(time.Now().Add(time.Millisecond))
 	require.NoError(t, err)

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -136,7 +136,7 @@ func TestInitProxyTCPRuleRejectsInvalidTarget(t *testing.T) {
 }
 
 func testConn(t *testing.T) (net.Conn, net.Listener) {
-	ln, err := net.Listen("tcp", "127.0.0.1:1234")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	require.NotNil(t, ln)
 	con, err := net.Dial(ln.Addr().Network(), ln.Addr().String())
@@ -159,17 +159,14 @@ func TestFakePacketBytes(t *testing.T) {
 func TestRunMatchTCP(t *testing.T) {
 	rules := parseRules(t)
 	require.NotEmpty(t, rules)
-	conn, ln := testConn(t)
-	defer func() {
-		conn.Close()
-		ln.Close()
-	}()
 	var (
 		match *Rule
 		err   error
 	)
 
-	match, err = rules.Match("tcp", conn.LocalAddr(), conn.RemoteAddr())
+	srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50000}
+	dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+	match, err = rules.Match("tcp", srcAddr, dstAddr)
 	require.NoError(t, err)
 	require.NotNil(t, match)
 	require.Equal(t, "test", match.Target)
@@ -178,17 +175,14 @@ func TestRunMatchTCP(t *testing.T) {
 func TestRunMatchUDP(t *testing.T) {
 	rules := parseRules(t)
 	require.NotEmpty(t, rules)
-	conn, ln := testConn(t)
-	defer func() {
-		conn.Close()
-		ln.Close()
-	}()
 	var (
 		match *Rule
 		err   error
 	)
 
-	match, err = rules.Match("udp", conn.LocalAddr(), conn.RemoteAddr())
+	srcAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50000}
+	dstAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+	match, err = rules.Match("udp", srcAddr, dstAddr)
 	require.NoError(t, err)
 	require.NotNil(t, match)
 	require.Equal(t, "test", match.Target)


### PR DESCRIPTION
CI was failing because severals tests were trying to bind to a fixed TCP ports like 1234 or 1235.
This PR replace those fixed ports with OS-assigned ephemeral ports.